### PR TITLE
platin: make util.which work with path in cmd

### DIFF
--- a/tools/platin/lib/core/utils.rb
+++ b/tools/platin/lib/core/utils.rb
@@ -140,6 +140,9 @@ module PML
   #
   def which(cmd)
     return nil unless cmd && cmd.length > 0
+    if cmd.include?(File::SEPARATOR)
+      return cmd if File.executable? cmd
+    end
     ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
       binary = File.join(path, "#{cmd}")
       return binary if File.executable? binary


### PR DESCRIPTION
Given an absolute or even relative path, 'which' should just check if the given path is executable. Currently it rejects e.g. the absolute path to a3patmos and I don't see why it should.
