### PR TITLE
temporary fix for disappearing type info MMO

### DIFF
--- a/lib/CodeGen/StackColoring.cpp
+++ b/lib/CodeGen/StackColoring.cpp
@@ -542,7 +542,7 @@ void StackColoring::remapInstructions(DenseMap<int, int> &SlotRemap) {
         if (!V || !isa<AllocaInst>(V)) {
           // Clear mem operand since we don't know for sure that it doesn't
           // alias a merged alloca.
-          MMO->setValue(0);
+          //MMO->setValue(0);
           continue;
         }
         const AllocaInst *AI= cast<AllocaInst>(V);


### PR DESCRIPTION
This stack coloring code wipes out type information we use to reconstruct a
useful machine call graph. The part has been reverted on upstream LLVM as well.
