### PR TITLE
platin: support for ERB templates in AIS export

### DIFF
--- a/tools/platin/lib/analysis/transform.rb
+++ b/tools/platin/lib/analysis/transform.rb
@@ -747,4 +747,70 @@ class SymbolicBoundTransformation
   end
 end
 
+#
+# Lookup (by implicitly transforming down) PC markers from bitcode down to
+# machine code (best effort based)
+#
+class MarkerLookup
+  attr_reader :pml, :options
+  def initialize(pml, options)
+    @pml, @options = pml, options
+  end
+
+  # Return machine code block for bitcode marker or nil if marker cannot be transformed
+  # XXX only simple transformations (to a single mc block succeed) work
+  def transform(marker)
+    markers = {}
+    @pml.bitcode_functions.each { |f|
+        f.blocks.each { |bb|
+            bb.instructions.each { |i|
+              if i.marker
+                (markers[i.marker]||=[]) << bb
+              end
+            }
+        }
+    }
+
+    unless markers.include? marker
+      debug(options, :transform) { "Marker #{marker} not found" }
+      return nil
+    end
+
+    # XXX we can only handle a unique marker
+    if markers[marker].size > 1
+      debug(options, :transform) { "Cannot transform duplicated marker" }
+      return nil
+    else
+      bb = markers[marker].first
+    end
+
+    # get relation graph
+    function = bb.function
+    rg_src_level    = :src
+    rg_target_level = :dst
+    if ! @pml.relation_graphs.has_named?(function.name, rg_src_level)
+      debug(options, :transform) { "Cannot transform marker without relation graph" }
+      return nil
+    end
+    rg = @pml.relation_graphs.by_name(function.name, rg_src_level)
+
+    blockmap = {}
+    blocks = [ bb ]
+    #loopblock = marker.loopheader if marker.kind_of?(Loop)
+    #blocks = ff.lhs.map { |t| t.programpoint }
+    #blocks.push(loopblock) if loopblock
+    #blocks.concat(ff.rhs.referenced_loops.map { |lref| lref.loopheader })
+    blocks.each { |b|
+      ns = rg.nodes.by_basic_block(b, rg_src_level)
+      return nil if ns.length != 1
+      n = ns.first
+      return nil if n.unmapped?
+      # find (unique) progress node for B
+      nb = n.get_block(rg_target_level)
+      blockmap[b] = nb
+    }
+    return blockmap[bb]
+  end
+end
+
 end # module PML

--- a/tools/platin/lib/ext/ait.rb
+++ b/tools/platin/lib/ext/ait.rb
@@ -213,6 +213,15 @@ class Edge
   end
 end
 
+class ProgramPoint
+  # generic helper that returns the address in hex
+  def ais_addr
+    # make sure we have an address (throw exception if not)
+    assert("no ais_ref") { ais_ref }
+    "0x#{address.to_s(16)}"
+  end
+end
+
 # class to export PML information to AIS
 class AISExporter
 

--- a/tools/platin/lib/tools/pml.rb
+++ b/tools/platin/lib/tools/pml.rb
@@ -151,6 +151,22 @@ class PMLTool
     puts "" unless set.empty?
   end
 
+  def lookup_marker(marker)
+    ml = MarkerLookup.new(pml,options)
+    begin
+      pp = ml.transform(Integer(marker))
+    rescue ArgumentError
+      warn("marker must be integer")
+      return
+    end
+    if pp == nil
+      warn("failed to transform marker '#{marker}'") if pp == nil
+    else
+      puts "transformed marker '#{marker}' -> #{pp}"
+    end
+  end
+
+
   def PMLTool.run(pml,options)
     tool = PMLTool.new(pml, options)
     if(options.validate)
@@ -160,6 +176,7 @@ class PMLTool
     tool.print_flowfacts if options.print_flowfacts
     tool.print_valuefacts if options.print_valuefacts
     tool.print_timings(options.print_profiles) if options.print_timings || options.print_profiles
+    tool.lookup_marker(options.pc_marker_lookup) if options.pc_marker_lookup
 
     if(options.stats)
       stats = {}
@@ -197,6 +214,9 @@ class PMLTool
     opts.on("--print-all", "print all analysis results stored in PML file") {
       opts.options.print_markers = opts.options.print_flowfacts =
         opts.options.print_valuefacts = opts.options.print_timing = true
+    }
+    opts.on("--lookup-pc-marker MARKER", "lookup MARKER on the machine code level") { |m|
+      opts.options.pc_marker_lookup = m
     }
   end
 end

--- a/tools/platin/lib/tools/pml2ais.rb
+++ b/tools/platin/lib/tools/pml2ais.rb
@@ -5,6 +5,7 @@
 #
 require 'platin'
 require 'ext/ait'
+require 'core/utils'
 include PML
 
 class AisExportTool
@@ -15,6 +16,7 @@ class AisExportTool
     opts.on("--ais-header-file FILE", "the contents of this file is copied verbatim to the final AIS file") { |file|
       opts.options.ais_header_file = file
     }
+    ERBTemplate.add_config_options(opts)
     opts.on("--ais-disable-exports LIST","AIS information that should not be exported (see --help=ais)") { |list|
       opts.options.ais_disable_export = Set.new(list.split(/\s*,\s*/))
     }
@@ -98,6 +100,8 @@ class AisExportTool
         }
         ais.export_stack_cache_annotations()
       end
+
+      ERBTemplate.new(pml, options, options.ff_template_file).render(outfile) if options.ff_template_file
       statistics("AIS",
                  "exported flow facts" => ais.stats_generated_facts,
                  "unsupported flow facts" => ais.stats_skipped_flowfacts) if options.stats


### PR DESCRIPTION
To generate complicated AIS annotations, which may depend on addresses in the binary (or any other information we have in the PML), a Ruby ERB template can be used via the "--ff-template FILE" option.

Here are examples for templated annotations (based on the Debie1 Worst Case Tool Challenge annotations):

ais.tmpl snippet

```
# no call to Set_SU_Error
# "should not be reachable" is just an assertion generating a warning
snippet "Set_SU_Error" should not be reachable;
# list of "never executed" annotations emitted below
<% @pml.machine_functions.each { |mf|
        mf.instructions.select { |i| i.callees.include? "Set_SU_Error" }. each { |i| %>
<%= "instruction #{i.ais_addr} is never executed;" -%>
<% }} %>
```

results in .ais

```
# no call to Set_SU_Error
snippet "Set_SU_Error" should not be reachable;
# list of "never executed" annotations emitted below
instruction 0x21d3c is never executed;
instruction 0x21ddc is never executed;
instruction 0x23244 is never executed;
instruction 0x233f4 is never executed;
instruction 0x22f04 is never executed;
instruction 0x22f94 is never executed;
instruction 0x23014 is never executed;
instruction 0x23084 is never executed;
instruction 0x230f4 is never executed;
instruction 0x227b4 is never executed;
```

ais.tmpl snippet

```
# flow constraint on the loop header which cannot be symbolically expressed in AIS.
# use AIS templating to compute read_ad_channel_l1 from PML
<% read_ad_channel_l1 = @pml.machine_functions.by_label_or_name('Read_AD_Channel').loops[0].loopheader -%>
# use address of read_ad_channel_l1 to emit flow constraint
flow sum (<%= read_ad_channel_l1.ais_addr -%>) <= 0; #no conversions aborted
```

results in .ais

```
flow sum (0x22654) <= 0; #no conversions aborted
```
