### PR TITLE
Redirect platin ruby version fallback message to stderr so it does not c...

### DIFF
--- a/tools/platin/ext/detect_ruby_commands
+++ b/tools/platin/ext/detect_ruby_commands
@@ -32,7 +32,7 @@ detect_ruby() {
 	echo "ruby not found. Please install ruby (e.g., sudo aptitude install ruby1.9.1)" >&2
 	exit 1
     elif [ -z "${RUBY19}" ] ; then
-	echo "ruby1.9 not found. Falling back to unsupported ruby version `${RUBY} -v`"
+	echo "ruby1.9 not found. Falling back to unsupported ruby version `${RUBY} -v`" >&2
     fi
 }
 


### PR DESCRIPTION
...onfuse clang

If this is not done, patmos-clang will interpret the error message as a list of files and fail in the patmos-benchmarks build process.