### PR TITLE
Disallow instruction with label operand in a bundle

### DIFF
--- a/lib/Target/Patmos/AsmParser/PatmosAsmParser.cpp
+++ b/lib/Target/Patmos/AsmParser/PatmosAsmParser.cpp
@@ -373,12 +373,15 @@ MatchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
       MCOperand &MCO = Inst.getOperand( ImmOpNo );
 
       if (MCO.isExpr()) {
-        // If we have an expression, use ALUl, but only if this is
-        // not a bundled op
-        if (HasALUlVariant(Inst.getOpcode(), ALUlOpcode) && !InBundle) {
-          Inst.setOpcode(ALUlOpcode);
-          // ALUl counts as two operations
-          BundleCounter++;
+        if (HasALUlVariant(Inst.getOpcode(), ALUlOpcode)){
+          if (InBundle) {
+            return Error(IDLoc, "long immediate instruction cannot be in the second slot of a bundle");
+          } else {
+            // If we have an expression and can use ALUl, do so
+            Inst.setOpcode(ALUlOpcode);
+            // ALUl counts as two operations
+            BundleCounter++;
+          }
         }
       } else {
         assert(MCO.isImm() && "expected immediate operand for ALUi format");


### PR DESCRIPTION
When compiling assembly, can no longer create a bundle where the first instruction uses a label operand, since it would need to be a long immediate instruction and therefore can't be part of a bundle. Fixes #15.
Tests for this change will be provided as a PR to the benchmark repository.

Also includes a change to the error message thrown in #14 to provide better information about the error. Instead of the old message:
```
[Single-path] Cannot rewrite call in main (indirect call?)
```
it will throw the message:
```
[Single-path] Cannot find function '__divsi3' to rewrite. Was called by 'main' (indirect call?)
```
