### PR TITLE
Remove duplicate

### DIFF
--- a/lib/Support/Triple.cpp
+++ b/lib/Support/Triple.cpp
@@ -245,7 +245,6 @@ static Triple::ArchType parseArch(StringRef ArchName) {
     .Case("mips64el", Triple::mips64el)
     .Case("r600", Triple::r600)
     .Case("hexagon", Triple::hexagon)
-    .Case("patmos", Triple::patmos)
     .Case("s390x", Triple::systemz)
     .Case("sparc", Triple::sparc)
     .Cases("sparcv9", "sparc64", Triple::sparcv9)

--- a/lib/Support/Triple.cpp
+++ b/lib/Support/Triple.cpp
@@ -170,7 +170,6 @@ Triple::ArchType Triple::getArchTypeForLLVMName(StringRef Name) {
     .Case("mips64", mips64)
     .Case("mips64el", mips64el)
     .Case("msp430", msp430)
-    .Case("patmos", patmos)
     .Case("ppc64", ppc64)
     .Case("ppc32", ppc)
     .Case("ppc", ppc)


### PR DESCRIPTION
The arch type `.Case("patmos", patmos)` was present twice in `Triple::getArchTypeForLLVMName` and `Triple::ArchType parseArch`