### PR TITLE
Add benchmark tests to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
     # Build newlib
     - git clone https://github.com/t-crest/patmos-newlib
     - cd patmos-newlib
+    - git checkout 87c47d06e216c1d54c7b0cb7a580dff85f19e2cd
     - mkdir build
     - cd build
     - ../configure  --target=patmos-unknown-unknown-elf AR_FOR_TARGET=ar RANLIB_FOR_TARGET=ranlib LD_FOR_TARGET=ld CC_FOR_TARGET=$TRAVIS_BUILD_DIR/build/bin/clang CFLAGS_FOR_TARGET="-target patmos-unknown-unknown-elf -O3" --prefix=$TRAVIS_BUILD_DIR/build/local
@@ -70,7 +71,7 @@ jobs:
     - tar -xvf patmos-llvm*.tar.gz
     - cd ..
     # Download benchmark repo
-    - git clone https://github.com/emoun/patmos-benchmarks bench
+    - git clone https://github.com/t-crest/patmos-benchmarks bench
     - cd bench
     - mkdir build
     - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,64 +1,76 @@
 language: cpp
 compiler: gcc
+os: linux
+dist: bionic
+
+cache:
+  directories: build/local
+
+before_script:
+# Set path to binary dependencies
+- export PATH=$TRAVIS_BUILD_DIR/build/local/bin:$PATH
+# Install boost because of pasim
+- sudo apt-get update -qq
+- sudo apt-get install libboost-program-options-dev
 
 jobs:
   include:
-    - os: linux
-      dist: bionic
-      before_script:
-      - mkdir build
-      - cd build
-      - mkdir local
-      - cd local
-      # Dowload Dependencies (compiler-rt, gold, patmos-simulator)
-      - wget -O patmos-compiler-rt.tar.gz "https://github.com/t-crest/patmos-compiler-rt/releases/download/v1.0.0-rc-1/patmos-compiler-rt-v1.0.0-rc-1.tar.gz"
-      - wget -O patmos-gold.tar.gz "https://github.com/t-crest/patmos-gold/releases/download/v1.0.0-rc-1/patmos-gold-v1.0.0-rc-1.tar.gz"
-      - wget -O patmos-simulator.tar.gz "https://github.com/t-crest/patmos-simulator/releases/download/1.0.0/patmos-simulator-x86_64-linux-gnu.tar.gz"
-      # Extract dependencies
-      - tar -xvf patmos-compiler-rt.tar.gz
-      - tar -xvf patmos-gold.tar.gz
-      - tar -xvf patmos-simulator.tar.gz
-      - cd ../..
-      # Install boost because of pasim
-      - sudo apt-get update -qq
-      - sudo apt-get install libboost-program-options-dev
-      # Set path to binary dependencies
-      - export PATH=$TRAVIS_BUILD_DIR/build/local/bin:$PATH
+  - stage: dependencies
+    script:
+    - mkdir -p build/local
+    - cd build/local
+    # Empty cache from last run (no-op if no cache)
+    - rm -rf *
+    # Dowload Dependencies (compiler-rt, gold, patmos-simulator)
+    - wget -O patmos-compiler-rt.tar.gz "https://github.com/t-crest/patmos-compiler-rt/releases/download/v1.0.0-rc-1/patmos-compiler-rt-v1.0.0-rc-1.tar.gz"
+    - wget -O patmos-gold.tar.gz "https://github.com/t-crest/patmos-gold/releases/download/v1.0.0-rc-1/patmos-gold-v1.0.0-rc-1.tar.gz"
+    - wget -O patmos-simulator.tar.gz "https://github.com/t-crest/patmos-simulator/releases/download/1.0.0/patmos-simulator-x86_64-linux-gnu.tar.gz"
+    # Extract dependencies
+    - tar -xvf patmos-compiler-rt.tar.gz
+    - tar -xvf patmos-gold.tar.gz
+    - tar -xvf patmos-simulator.tar.gz
+    - cd ../..
       
-script:
-# Download clang
-- cd tools
-- git clone https://github.com/t-crest/patmos-clang/ clang
-- cd ..
-# Build LLVM
-- cd build
-- cmake .. -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=local -DLLVM_TARGETS_TO_BUILD=Patmos -DLLVM_DEFAULT_TARGET_TRIPLE=patmos-unknown-unknown-elf -DCLANG_ENABLE_ARCMT=false -DCLANG_ENABLE_STATIC_ANALYZER=false -DCLANG_ENABLE_TESTS=false -DCLANG_ENABLE_DOCS=false -DCLANG_BUILD_EXAMPLES=false
-- make UnitTests llc llvm-link clang llvm-config llvm-objdump opt 
-# Build newlib
-- git clone https://github.com/t-crest/patmos-newlib
-- cd patmos-newlib
-- mkdir build
-- cd build
-- ../configure  --target=patmos-unknown-unknown-elf AR_FOR_TARGET=ar RANLIB_FOR_TARGET=ranlib LD_FOR_TARGET=ld CC_FOR_TARGET=$TRAVIS_BUILD_DIR/build/bin/clang CFLAGS_FOR_TARGET="-target patmos-unknown-unknown-elf -O3" --prefix=$TRAVIS_BUILD_DIR/build/local
-# We use 'MAKEINFO=true' to avoid building documentation
-- make -j MAKEINFO=true
-- make -j MAKEINFO=true install
-- cd ../..
-- env DEBUG_TYPE="" LINK_LIBS=$TRAVIS_BUILD_DIR/build/local/patmos-unknown-unknown-elf/lib ./bin/llvm-lit ../test --filter=Patmos -v
-- cd ..
-
-before_deploy:
-- cd build
-- make box
-- cd ..
-
-deploy:
-- provider: releases
-  api_key:
-    secure: NhHMOmBieRgW+0YCmnG2M4GSiv614JKTxLg3PWh4AkqxUCWCvCEovy0QcvHTJslDD9Y1ZDlo5P84pwDziODCt2bmVPXhGOQSiBL8gD/bMaI7Xw8uQAha9gQ3lgfBKm0TWk6lPOBKG7ECh7bQHjIvR6oN/F5Q7DWHxdLmi2sMblgQIE9HloB5aCtvbjH24GBJZbMTPd65g7CgMIyQUGB5yQWeLwOHONCmtyXFgTH3tbaMKL17wEhHwwNgWOrM7H0kdlqKCOu9BJ2d63p/539BdV7sMWuoZo33KLuC9XizGEHDak1Xab7jc2gKts4qpAoew1s1CREk63FuNnrSp+ujmeLluHrdWzvI9mJrciRvpLr+RozO+JGbXumAv9zlZhYqpYvMm81QFF1o/Zo1pzBcmz7bt49p+wlD3mipMxPFrv6gZ49xJ+pEfKTnZ6+NOFW+Q4rikHsRYNV8l+FCdre97w1t8Wup+EwKQ7INiBR378RNP7p+51UgOaRyDAnyNdc34ms27D2HI/+KyKWBtVJOKKrtZyCYBSsGJ+yRACTaBhK4gpi3uzF0HAPlq41V1+Ioa9P2mrbZ0zakA9EM5WToihZv0f66Qey8r3R5lpU5i+d8wa8YBr0TnE+JaLDXZC8Nf7dllmRP+anO1v3PinyXQ/qTMxgt/iwKtJHuP4ZZk3w=
-  file_glob: true
-  file: "build/patmos-llvm*.tar.gz"
-  skip_cleanup: true
-  on:
-    tags: true
-    repo: t-crest/patmos-llvm
+  - stage: build
+    script:
+    # print contents of cache:
+    - ls build/local
+    # Download clang
+    - cd tools
+    - git clone https://github.com/t-crest/patmos-clang/ clang
+    - cd ..
+    # Build LLVM
+    - cd build
+    - cmake .. -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=local -DLLVM_TARGETS_TO_BUILD=Patmos -DLLVM_DEFAULT_TARGET_TRIPLE=patmos-unknown-unknown-elf -DCLANG_ENABLE_ARCMT=false -DCLANG_ENABLE_STATIC_ANALYZER=false -DCLANG_ENABLE_TESTS=false -DCLANG_ENABLE_DOCS=false -DCLANG_BUILD_EXAMPLES=false
+    - make UnitTests llc llvm-link clang llvm-config llvm-objdump opt 
+    # Build newlib
+    - git clone https://github.com/t-crest/patmos-newlib
+    - cd patmos-newlib
+    - mkdir build
+    - cd build
+    - ../configure  --target=patmos-unknown-unknown-elf AR_FOR_TARGET=ar RANLIB_FOR_TARGET=ranlib LD_FOR_TARGET=ld CC_FOR_TARGET=$TRAVIS_BUILD_DIR/build/bin/clang CFLAGS_FOR_TARGET="-target patmos-unknown-unknown-elf -O3" --prefix=$TRAVIS_BUILD_DIR/build/local
+    # We use 'MAKEINFO=true' to avoid building documentation
+    - make -j MAKEINFO=true
+    - make -j MAKEINFO=true install
+    - cd ../..
+    - env DEBUG_TYPE="" LINK_LIBS=$TRAVIS_BUILD_DIR/build/local/patmos-unknown-unknown-elf/lib ./bin/llvm-lit ../test --filter=Patmos -v
+    # Prepare release artifact and put it in cache
+    - make box
+    - mv patmos-llvm*.tar.gz local/
+    - cd ..
+  
+  - stage: deploy
+    before_script:
+    # print contents of cache:
+    - ls build/local
+    script: skip
+    deploy:
+    - provider: releases
+      api_key:
+        secure: NhHMOmBieRgW+0YCmnG2M4GSiv614JKTxLg3PWh4AkqxUCWCvCEovy0QcvHTJslDD9Y1ZDlo5P84pwDziODCt2bmVPXhGOQSiBL8gD/bMaI7Xw8uQAha9gQ3lgfBKm0TWk6lPOBKG7ECh7bQHjIvR6oN/F5Q7DWHxdLmi2sMblgQIE9HloB5aCtvbjH24GBJZbMTPd65g7CgMIyQUGB5yQWeLwOHONCmtyXFgTH3tbaMKL17wEhHwwNgWOrM7H0kdlqKCOu9BJ2d63p/539BdV7sMWuoZo33KLuC9XizGEHDak1Xab7jc2gKts4qpAoew1s1CREk63FuNnrSp+ujmeLluHrdWzvI9mJrciRvpLr+RozO+JGbXumAv9zlZhYqpYvMm81QFF1o/Zo1pzBcmz7bt49p+wlD3mipMxPFrv6gZ49xJ+pEfKTnZ6+NOFW+Q4rikHsRYNV8l+FCdre97w1t8Wup+EwKQ7INiBR378RNP7p+51UgOaRyDAnyNdc34ms27D2HI/+KyKWBtVJOKKrtZyCYBSsGJ+yRACTaBhK4gpi3uzF0HAPlq41V1+Ioa9P2mrbZ0zakA9EM5WToihZv0f66Qey8r3R5lpU5i+d8wa8YBr0TnE+JaLDXZC8Nf7dllmRP+anO1v3PinyXQ/qTMxgt/iwKtJHuP4ZZk3w=
+      file_glob: true
+      file: "build/local/patmos-llvm*.tar.gz"
+      skip_cleanup: true
+      on:
+        tags: true
+        repo: t-crest/patmos-llvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,9 @@ jobs:
     # Download clang
     - cd tools
     - git clone https://github.com/t-crest/patmos-clang/ clang
-    - cd ..
+    - cd clang
+    - git checkout 73474a8ae98f1a281a03c440a4d8b9987029cf4e
+    - cd ../..
     # Build LLVM
     - cd build
     - cmake .. -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=local -DLLVM_TARGETS_TO_BUILD=Patmos -DLLVM_DEFAULT_TARGET_TRIPLE=patmos-unknown-unknown-elf -DCLANG_ENABLE_ARCMT=false -DCLANG_ENABLE_STATIC_ANALYZER=false -DCLANG_ENABLE_TESTS=false -DCLANG_ENABLE_DOCS=false -DCLANG_BUILD_EXAMPLES=false
@@ -73,6 +75,7 @@ jobs:
     # Download benchmark repo
     - git clone https://github.com/t-crest/patmos-benchmarks bench
     - cd bench
+    - git checkout 8bca6cc6490540599c7e9ec5b25816e58f611560
     - mkdir build
     - cd build
     - cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/patmos-clang-toolchain.cmake -DENABLE_TESTING=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ os: linux
 dist: bionic
 
 cache:
-  directories: build/local
+  directories: 
+  - build/local
+  - build/bench
 
 before_script:
 # Set path to binary dependencies
@@ -15,7 +17,7 @@ before_script:
 
 jobs:
   include:
-  - stage: dependencies
+  - stage: "Get Dependencies"
     script:
     - mkdir -p build/local
     - cd build/local
@@ -30,8 +32,10 @@ jobs:
     - tar -xvf patmos-gold.tar.gz
     - tar -xvf patmos-simulator.tar.gz
     - cd ../..
+    # Delete benchmark if present
+    - rm -rf build/bench
       
-  - stage: build
+  - stage: "Build and Test LLVM"
     script:
     # print contents of cache:
     - ls build/local
@@ -59,10 +63,31 @@ jobs:
     - mv patmos-llvm*.tar.gz local/
     - cd ..
   
-  - stage: deploy
+  - stage: "Build Test Suite"
+    script:
+    - cd build/local
+    # Extract LLVM artifacts
+    - tar -xvf patmos-llvm*.tar.gz
+    - cd ..
+    # Download benchmark repo
+    - git clone https://github.com/emoun/patmos-benchmarks bench
+    - cd bench
+    - mkdir build
+    - cd build
+    - cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/patmos-clang-toolchain.cmake -DENABLE_TESTING=true
+    - make
+    - cd ../../..
+       
+  - stage: "Run Test Suite"
+    script:
+    - cd build/bench/build
+    - ctest -j$(grep -c ^processor /proc/cpuinfo)
+    - cd ../../..
+    - rm -rf build/bench
+    
+  - stage: "Deploy"
+    if: tag IS present
     before_script:
-    # print contents of cache:
-    - ls build/local
     script: skip
     deploy:
     - provider: releases

--- a/lib/Target/Patmos/SinglePath/PatmosSPBundling.cpp
+++ b/lib/Target/Patmos/SinglePath/PatmosSPBundling.cpp
@@ -202,7 +202,7 @@ void PatmosSPBundling::bundleScope(SPScope* root){
   }
 
   std::for_each(root->child_begin(), root->child_end(), [&](auto subscope){
-    bundleScope(subscope);
+    this->bundleScope(subscope);
   });
 }
 


### PR DESCRIPTION
Adds the running of tests from the [patmos-benchmarks](https://github.com/t-crest/patmos-benchmarks) repository as part of the CI build.
